### PR TITLE
Fixed Deleted Math Module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,6 @@
         <module>files</module>
         <module>ierisfx</module>
         <module>reflection</module>
-        <module>math</module>
         <module>economy</module>
     </modules>
 


### PR DESCRIPTION
It was still mentioned in the POM for the Library, now it should be better deleted.

Fix for commit:
51ac19649e4ef87018a0bd74e3591e1ca8df5562