### PR TITLE
Adding maven-settings-action

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -25,12 +25,18 @@ jobs:
           cache: maven
           server-id: ierislib # Value of the distributionManagement/repository/id field of the pom.xml
           settings-path: ${{ github.workspace }} # location for the settings.xml file
-
+      - name: Configure Maven settings.xml
+        uses: s4u/maven-settings-action@v2.3.0
+        with:
+          servers: |
+            [{
+              "id": "ierislib",
+              "username": "${{ github.actor }}",
+              "password": "${{ secrets.GITHUB_TOKEN }}"
+            }]
       - name: Build with Maven
         run: mvn --batch-mode package --file pom.xml
 
       - name: Publish to GitHub Packages through Maven
         run: mvn deploy --fail-at-end --settings ${{ github.workspace }}/settings.xml
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          
+


### PR DESCRIPTION
Automatically picking up the GitHub token wasn't working, so hoping that the maven-settings-action can create a satisfactory settings.xml temporarily for maven to have the credentials necessary